### PR TITLE
gorm Find method doesn't return 'ErrRecordNotFound'

### DIFF
--- a/model/user.go
+++ b/model/user.go
@@ -23,7 +23,7 @@ func (u *User) CheckPassword(password string) bool {
 // GetUserByUsername func
 func GetUserByUsername(username string) (*User, error) {
 	var user User
-	if err := db.Where("username=?", username).Find(&user).Error; err != nil {
+	if err := db.Where("username=?", username).First(&user).Error; err != nil {
 		return nil, err
 	}
 	return &user, nil


### PR DESCRIPTION
According to the documentation [gorm](https://gorm.io/docs/query.html#Retrieving-a-single-object), the `Find` method does not return error `ErrRecordNotFound` if no record found. 
The function `GetUserByUsername` should catch error `ErrRecordNotFound`.
https://github.com/bonfy/go-mega-code/blob/2940d8a8ada7e9ea2d214495f7dc6958c4e45c16/model/user.go#L24
Other branches should also need this change.